### PR TITLE
Add compliant and noncompliant examples of cloudformation/checkov-custom-s3-default-encryption-kms@v1.0

### DIFF
--- a/src/IaC/detectors/cloudformation/checkov-custom-s3-default-encryption-kms/compliant.yaml
+++ b/src/IaC/detectors/cloudformation/checkov-custom-s3-default-encryption-kms/compliant.yaml
@@ -1,0 +1,25 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=checkov-custom-s3-default-encryption-kms@v1.0 defects=0}
+Resources:
+  GoodS3DefaultEncryptionKMS:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-bucket
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        RestrictPublicBuckets: true
+        IgnorePublicAcls: true
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+      LoggingConfiguration:
+        DestinationBucketName: String
+        LogFilePrefix: String
+      # Compliant: `BucketEncryption` is enabled.
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+# {/fact}

--- a/src/IaC/detectors/cloudformation/checkov-custom-s3-default-encryption-kms/non-compliant.yaml
+++ b/src/IaC/detectors/cloudformation/checkov-custom-s3-default-encryption-kms/non-compliant.yaml
@@ -1,0 +1,24 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=checkov-custom-s3-default-encryption-kms@v1.0 defects=1}
+Resources:
+  BadS3DefaultEncryptionKMS:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-bucket
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        RestrictPublicBuckets: true
+        IgnorePublicAcls: true
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+      LoggingConfiguration:
+        DestinationBucketName: String
+        LogFilePrefix: String
+      AccessControl: LogDeliveryWrite
+      # Noncompliant: `BucketEncryption` is not enabled.
+      MetricsConfigurations:
+        - Id: BucketMetrics
+# {/fact}


### PR DESCRIPTION
*Description of changes:*
* Rules Added : cloudformation/checkov-custom-s3-default-encryption-kms@v1.0
* Added new compliant and non compliant examples.