### PR TITLE
Add compliant and noncompliant examples of cloudformation/checkov-custom-aurora-mysql-backtrack@v1.0

### DIFF
--- a/src/IaC/detectors/cloudformation/checkov-custom-aurora-mysql-backtrack/compliant.yaml
+++ b/src/IaC/detectors/cloudformation/checkov-custom-aurora-mysql-backtrack/compliant.yaml
@@ -1,0 +1,15 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=checkov-custom-aurora-mysql-backtrack@v1.0 defects=0}
+Resources:
+  ExampleRDS:
+    Type: "AWS::RDS::DBCluster"
+    Properties:
+      StorageEncrypted: true
+      EnableIAMDatabaseAuthentication: true
+      # Compliant: Amazon Aurora MySQL cluster has backtracking enabled.
+      BacktrackWindow: 1
+      DatabaseName: MyCluster
+      Engine: 'aurora-mysql'
+# {/fact}

--- a/src/IaC/detectors/cloudformation/checkov-custom-aurora-mysql-backtrack/non-compliant.yaml
+++ b/src/IaC/detectors/cloudformation/checkov-custom-aurora-mysql-backtrack/non-compliant.yaml
@@ -1,0 +1,15 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=checkov-custom-aurora-mysql-backtrack@v1.0 defects=1}
+Resources:
+  ExampleRDS:
+    Type: "AWS::RDS::DBCluster"
+    Properties:
+      StorageEncrypted: true
+      EnableIAMDatabaseAuthentication: true
+      # Noncompliant: Amazon Aurora MySQL cluster has backtracking disabled.
+      BacktrackWindow: 0
+      DatabaseName: MyCluster
+      Engine: 'aurora-mysql'
+# {/fact}


### PR DESCRIPTION
*Description of changes:*
* Rules Added: cloudformation/checkov-custom-aurora-mysql-backtrack@v1.0.
* Added new compliant and non compliant examples.